### PR TITLE
Tweak download URLs

### DIFF
--- a/A4xCalc/auroramod.json
+++ b/A4xCalc/auroramod.json
@@ -40,22 +40,22 @@
         {
             "version": "0.1.1",
             "target_aurora_version": "1",
-            "download_url": "https://raw.githubusercontent.com/Iceranger03/Releases/blob/master/A4xCalc/A4xCalc_v0.1.1.zip"
+            "download_url": "https://github.com/Iceranger03/Releases/raw/master/A4xCalc/A4xCalc_v0.1.1.zip"
         },
         {
             "version": "0.1.2",
             "target_aurora_version": "1",
-            "download_url": "https://raw.githubusercontent.com/Iceranger03/Releases/blob/master/A4xCalc/A4xCalc_v0.1.2.zip"
+            "download_url": "https://github.com/Iceranger03/Releases/raw/master/A4xCalc/A4xCalc_v0.1.2.zip"
         },
         {
             "version": "0.1.3",
             "target_aurora_version": "1",
-            "download_url": "https://raw.githubusercontent.com/Iceranger03/Releases/blob/master/A4xCalc/A4xCalc_v0.1.3.zip"
+            "download_url": "https://github.com/Iceranger03/Releases/raw/master/A4xCalc/A4xCalc_v0.1.3.zip"
         },
         {
             "version": "0.2.1",
             "target_aurora_version": "1",
-            "download_url": "https://raw.githubusercontent.com/Iceranger03/Releases/blob/master/A4xCalc/A4xCalc_v0.2.1.zip"
+            "download_url": "https://github.com/Iceranger03/Releases/raw/master/A4xCalc/A4xCalc_v0.2.1.zip"
         }
     ]
 }

--- a/A4xCalc/updates.txt
+++ b/A4xCalc/updates.txt
@@ -1,4 +1,4 @@
-0.1.1=https://github.com/Iceranger03/Releases/blob/master/A4xCalc/A4xCalc_v0.1.1.zip
-0.1.2=https://github.com/Iceranger03/Releases/blob/master/A4xCalc/A4xCalc_v0.1.2.zip
-0.1.3=https://github.com/Iceranger03/Releases/blob/master/A4xCalc/A4xCalc_v0.1.3.zip
-0.2.1=https://github.com/Iceranger03/Releases/blob/master/A4xCalc/A4xCalc_v0.2.1.zip
+0.1.1=https://github.com/Iceranger03/Releases/raw/master/A4xCalc/A4xCalc_v0.1.1.zip
+0.1.2=https://github.com/Iceranger03/Releases/raw/master/A4xCalc/A4xCalc_v0.1.2.zip
+0.1.3=https://github.com/Iceranger03/Releases/raw/master/A4xCalc/A4xCalc_v0.1.3.zip
+0.2.1=https://github.com/Iceranger03/Releases/raw/master/A4xCalc/A4xCalc_v0.2.1.zip


### PR DESCRIPTION
Since we're pointing at .zips checked into a repository rather than a GitHub Release, the URLs look a little different (which is fine).